### PR TITLE
Email recs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "snapfu",
-	"version": "1.0.8",
+	"version": "1.0.9",
 	"author": "searchspring",
 	"license": "MIT",
 	"description": "Command line interface for Snap!",

--- a/src/frameworks/preact.js
+++ b/src/frameworks/preact.js
@@ -24,9 +24,44 @@ export class ${name} extends Component {
 	}
 }`;
 
+const emailComponent = (name) => `import { h, Fragment, Component } from 'preact';
+import { observer } from 'mobx-react';
+
+import { Result } from '@searchspring/snap-preact-components';
+
+@observer
+export class ${name} extends Component {
+	render() {
+		const controller = this.props.controller;
+		const store = controller?.store;
+		const theme = {
+			components: {
+				image: {
+					lazy: false,
+				},
+			},
+		};
+		return (
+			<div>
+				{store.results.map((result, idx) => (
+					//****** IMPORTANT  *******//
+					// THIS OUTER "ss-emailrec" WRAPPER IS REQUIRED FOR EMAIL RECS TO WORK PROPERLY.
+					// DO NOT REMOVE OR EDIT IT
+					<div key={idx} id={\`ss-emailrec\${idx}\`} style={{ display: 'block', width: '240px' }}>
+						{/* make your result changes here  */}
+						<Result result={result} theme={theme}></Result>
+					</div>
+				))}
+			</div>
+		);
+	}
+}
+`;
+
 export const preact = {
 	template: {
 		dir: './src/components/Recommendations',
-		component: preactComponent,
+		default: preactComponent,
+		email: emailComponent,
 	},
 };

--- a/src/frameworks/preact.js
+++ b/src/frameworks/preact.js
@@ -61,7 +61,9 @@ export class ${name} extends Component {
 export const preact = {
 	template: {
 		dir: './src/components/Recommendations',
-		default: preactComponent,
-		email: emailComponent,
+		components: {
+			default: preactComponent,
+			email: emailComponent,
+		},
 	},
 };

--- a/src/init.js
+++ b/src/init.js
@@ -55,6 +55,11 @@ export const init = async (options) => {
 				return org.login;
 			});
 		});
+		let repos = await octokit.rest.repos.listForOrg({
+			org: 'searchspring',
+			type: 'public',
+			per_page: 500,
+		});
 
 		let questions = [
 			{
@@ -72,6 +77,13 @@ export const init = async (options) => {
 				message: "Please choose the framework you'd like to use:",
 				choices: ['preact'],
 				default: 'preact',
+			},
+			{
+				type: 'list',
+				name: 'template',
+				message: "Please choose the template you'd like to use:",
+				choices: repos.data.filter((repo) => repo.name.startsWith('snapfu-template-')),
+				default: 'snapfu-template-preact',
 			},
 			{
 				type: 'list',
@@ -141,8 +153,8 @@ export const init = async (options) => {
 		const repoUrlHTTP = `https://github.com/${answers.organization}/${answers.name}`;
 
 		// template repo URLs
-		const templateUrlSSH = `git@github.com:searchspring/snapfu-template-${answers.framework}.git`;
-		const templateUrlHTTP = `https://github.com/searchspring/snapfu-template-${answers.framework}`;
+		const templateUrlSSH = `git@github.com:searchspring/${answers.template}.git`;
+		const templateUrlHTTP = `https://github.com/searchspring/${answers.template}`;
 
 		if (!options.dev) {
 			console.log(`Cloning repository...`);
@@ -181,13 +193,11 @@ export const init = async (options) => {
 		await setBranchProtection(options, { organization: answers.organization, name: answers.name });
 
 		if (dir != cwd()) {
-			console.log(
-				`The ${chalk.blue(folderName)} directory has been created and initialized from ${chalk.blue(`snapfu-template-${answers.framework}`)}.`
-			);
+			console.log(`The ${chalk.blue(folderName)} directory has been created and initialized from ${chalk.blue(`${answers.template}`)}.`);
 			console.log(`Get started by installing package dependencies and creating a branch:`);
 			console.log(chalk.grey(`\n\tcd ${folderName} && npm install && git checkout -b development\n`));
 		} else {
-			console.log(`Current working directory has been initialized from ${chalk.blue(`snapfu-template-${answers.framework}`)}.`);
+			console.log(`Current working directory has been initialized from ${chalk.blue(`${answers.template}`)}.`);
 			console.log(`Get started by installing package dependencies and creating a branch:`);
 			console.log(chalk.grey(`\n\tnpm install && git checkout -b development\n`));
 		}

--- a/src/init.js
+++ b/src/init.js
@@ -77,149 +77,152 @@ export const init = async (options) => {
 		};
 
 		let repos = await fetchOrgReposPage();
-
-		let questions = [
-			{
-				type: 'input',
-				name: 'name',
-				validate: (input) => {
-					return input && input.length > 0;
-				},
-				message: 'Please choose the name of this repository:',
-				default: path.basename(dir),
-			},
-			{
-				type: 'list',
-				name: 'framework',
-				message: "Please choose the framework you'd like to use:",
-				choices: ['preact'],
-				default: 'preact',
-			},
-		];
-
-		const answers1 = await inquirer.prompt(questions);
-
-		let questions2 = [
-			{
-				type: 'list',
-				name: 'template',
-				message: "Please choose the template you'd like to use:",
-				choices: repos.filter((repo) => repo.name.startsWith(`snapfu-template-${answers1.framework}`)),
-				default: `snapfu-template-${answers1.framework}`,
-			},
-			{
-				type: 'list',
-				name: 'organization',
-				message: 'Please choose which github organization to create this repository in:',
-				choices: orgs,
-				default: 'searchspring-implementations',
-			},
-			{
-				type: 'input',
-				name: 'siteId',
-				message: 'Please enter the siteId as found in the SMC console (a1b2c3):',
-				validate: (input) => {
-					return input && input.length > 0 && /^[0-9a-z]{6}$/.test(input);
-				},
-			},
-			{
-				type: 'input',
-				name: 'secretKey',
-				message: 'Please enter the secretKey as found in the SMC console (32 characters):',
-				validate: (input) => {
-					return input && input.length > 0 && /^[0-9a-zA-Z]{32}$/.test(input);
-				},
-			},
-		];
-		const answers2 = await inquirer.prompt(questions2);
-		const answers = { ...answers1, ...answers2 };
-		try {
-			await new ConfigApi(answers.secretKey, options.dev).validateSite(answers.siteId);
-		} catch (err) {
-			console.log(chalk.red('Verification of siteId and secretKey failed.'));
-			console.log(chalk.red(err));
-			exit(1);
-		}
-
-		// create local directory
-		let folderName = await createDir(dir);
-
-		if (options.dev) {
-			console.log(chalk.blueBright('Skipping new repo creation...'));
+		if (!repos || !repos.length) {
+			console.log(chalk.red('failed to find any repos.'));
 		} else {
-			// create the remote repo
-			console.log(`Creating repository...`);
+			let questions = [
+				{
+					type: 'input',
+					name: 'name',
+					validate: (input) => {
+						return input && input.length > 0;
+					},
+					message: 'Please choose the name of this repository:',
+					default: path.basename(dir),
+				},
+				{
+					type: 'list',
+					name: 'framework',
+					message: "Please choose the framework you'd like to use:",
+					choices: ['preact'],
+					default: 'preact',
+				},
+			];
 
-			await octokit.repos
-				.createInOrg({
-					org: answers.organization,
-					name: answers.name,
-					private: true,
-					auto_init: true,
-				})
-				.then(() => console.log(`${chalk.greenBright(answers.name)}\n`))
-				.catch((err) => {
-					if (!err.message.includes('already exists')) {
-						console.log(chalk.red(err.message));
-						exit(1);
-					} else {
-						console.log(chalk.yellow('repository already exists\n'));
-					}
-				});
-		}
+			const answers1 = await inquirer.prompt(questions);
 
-		// newly create repo URLs
-		const repoUrlSSH = `git@github.com:${answers.organization}/${answers.name}.git`;
-		const repoUrlHTTP = `https://github.com/${answers.organization}/${answers.name}`;
-
-		// template repo URLs
-		const templateUrlSSH = `git@github.com:searchspring/${answers.template}.git`;
-		const templateUrlHTTP = `https://github.com/searchspring/${answers.template}`;
-
-		if (!options.dev) {
-			console.log(`Cloning repository...`);
+			let questions2 = [
+				{
+					type: 'list',
+					name: 'template',
+					message: "Please choose the template you'd like to use:",
+					choices: repos.filter((repo) => repo.name.startsWith(`snapfu-template-${answers1.framework}`)),
+					default: `snapfu-template-${answers1.framework}`,
+				},
+				{
+					type: 'list',
+					name: 'organization',
+					message: 'Please choose which github organization to create this repository in:',
+					choices: orgs,
+					default: 'searchspring-implementations',
+				},
+				{
+					type: 'input',
+					name: 'siteId',
+					message: 'Please enter the siteId as found in the SMC console (a1b2c3):',
+					validate: (input) => {
+						return input && input.length > 0 && /^[0-9a-z]{6}$/.test(input);
+					},
+				},
+				{
+					type: 'input',
+					name: 'secretKey',
+					message: 'Please enter the secretKey as found in the SMC console (32 characters):',
+					validate: (input) => {
+						return input && input.length > 0 && /^[0-9a-zA-Z]{32}$/.test(input);
+					},
+				},
+			];
+			const answers2 = await inquirer.prompt(questions2);
+			const answers = { ...answers1, ...answers2 };
 			try {
-				await cloneAndCopyRepo(repoUrlSSH, dir, false);
-				console.log(`${chalk.greenBright(repoUrlSSH)}\n`);
+				await new ConfigApi(answers.secretKey, options.dev).validateSite(answers.siteId);
 			} catch (err) {
-				await cloneAndCopyRepo(repoUrlHTTP, dir, false);
-				console.log(`${chalk.greenBright(repoUrlHTTP)}\n`);
+				console.log(chalk.red('Verification of siteId and secretKey failed.'));
+				console.log(chalk.red(err));
+				exit(1);
 			}
-		}
 
-		console.log(`Cloning template into ${dir}...`);
-		try {
-			await cloneAndCopyRepo(templateUrlSSH, dir, true, {
-				'snapfu.name': answers.name,
-				'snapfu.siteId': answers.siteId,
-				'snapfu.author': user.name,
-				'snapfu.framework': answers.framework,
-			});
-			console.log(`${chalk.greenBright(templateUrlSSH)}\n`);
-		} catch (err) {
-			await cloneAndCopyRepo(templateUrlHTTP, dir, true, {
-				'snapfu.name': answers.name,
-				'snapfu.siteId': answers.siteId,
-				'snapfu.author': user.name,
-				'snapfu.framework': answers.framework,
-			});
-			console.log(`${chalk.greenBright(templateUrlHTTP)}\n`);
-		}
+			// create local directory
+			let folderName = await createDir(dir);
 
-		// save secretKey mapping to creds.json
-		const { siteId, secretKey } = await auth.saveSecretKey(answers.secretKey, answers.siteId);
+			if (options.dev) {
+				console.log(chalk.blueBright('Skipping new repo creation...'));
+			} else {
+				// create the remote repo
+				console.log(`Creating repository...`);
 
-		await setRepoSecret(options, { siteId: answers.siteId, secretKey: answers.secretKey, organization: answers.organization, name: answers.name });
-		await setBranchProtection(options, { organization: answers.organization, name: answers.name });
+				await octokit.repos
+					.createInOrg({
+						org: answers.organization,
+						name: answers.name,
+						private: true,
+						auto_init: true,
+					})
+					.then(() => console.log(`${chalk.greenBright(answers.name)}\n`))
+					.catch((err) => {
+						if (!err.message.includes('already exists')) {
+							console.log(chalk.red(err.message));
+							exit(1);
+						} else {
+							console.log(chalk.yellow('repository already exists\n'));
+						}
+					});
+			}
 
-		if (dir != cwd()) {
-			console.log(`The ${chalk.blue(folderName)} directory has been created and initialized from ${chalk.blue(`${answers.template}`)}.`);
-			console.log(`Get started by installing package dependencies and creating a branch:`);
-			console.log(chalk.grey(`\n\tcd ${folderName} && npm install && git checkout -b development\n`));
-		} else {
-			console.log(`Current working directory has been initialized from ${chalk.blue(`${answers.template}`)}.`);
-			console.log(`Get started by installing package dependencies and creating a branch:`);
-			console.log(chalk.grey(`\n\tnpm install && git checkout -b development\n`));
+			// newly create repo URLs
+			const repoUrlSSH = `git@github.com:${answers.organization}/${answers.name}.git`;
+			const repoUrlHTTP = `https://github.com/${answers.organization}/${answers.name}`;
+
+			// template repo URLs
+			const templateUrlSSH = `git@github.com:searchspring/${answers.template}.git`;
+			const templateUrlHTTP = `https://github.com/searchspring/${answers.template}`;
+
+			if (!options.dev) {
+				console.log(`Cloning repository...`);
+				try {
+					await cloneAndCopyRepo(repoUrlSSH, dir, false);
+					console.log(`${chalk.greenBright(repoUrlSSH)}\n`);
+				} catch (err) {
+					await cloneAndCopyRepo(repoUrlHTTP, dir, false);
+					console.log(`${chalk.greenBright(repoUrlHTTP)}\n`);
+				}
+			}
+
+			console.log(`Cloning template into ${dir}...`);
+			try {
+				await cloneAndCopyRepo(templateUrlSSH, dir, true, {
+					'snapfu.name': answers.name,
+					'snapfu.siteId': answers.siteId,
+					'snapfu.author': user.name,
+					'snapfu.framework': answers.framework,
+				});
+				console.log(`${chalk.greenBright(templateUrlSSH)}\n`);
+			} catch (err) {
+				await cloneAndCopyRepo(templateUrlHTTP, dir, true, {
+					'snapfu.name': answers.name,
+					'snapfu.siteId': answers.siteId,
+					'snapfu.author': user.name,
+					'snapfu.framework': answers.framework,
+				});
+				console.log(`${chalk.greenBright(templateUrlHTTP)}\n`);
+			}
+
+			// save secretKey mapping to creds.json
+			const { siteId, secretKey } = await auth.saveSecretKey(answers.secretKey, answers.siteId);
+
+			await setRepoSecret(options, { siteId: answers.siteId, secretKey: answers.secretKey, organization: answers.organization, name: answers.name });
+			await setBranchProtection(options, { organization: answers.organization, name: answers.name });
+
+			if (dir != cwd()) {
+				console.log(`The ${chalk.blue(folderName)} directory has been created and initialized from ${chalk.blue(`${answers.template}`)}.`);
+				console.log(`Get started by installing package dependencies and creating a branch:`);
+				console.log(chalk.grey(`\n\tcd ${folderName} && npm install && git checkout -b development\n`));
+			} else {
+				console.log(`Current working directory has been initialized from ${chalk.blue(`${answers.template}`)}.`);
+				console.log(`Get started by installing package dependencies and creating a branch:`);
+				console.log(chalk.grey(`\n\tnpm install && git checkout -b development\n`));
+			}
 		}
 	} catch (err) {
 		console.log(chalk.red(err));

--- a/src/init.js
+++ b/src/init.js
@@ -78,12 +78,17 @@ export const init = async (options) => {
 				choices: ['preact'],
 				default: 'preact',
 			},
+		];
+
+		const answers1 = await inquirer.prompt(questions);
+
+		let questions2 = [
 			{
 				type: 'list',
 				name: 'template',
 				message: "Please choose the template you'd like to use:",
-				choices: repos.data.filter((repo) => repo.name.startsWith('snapfu-template-')),
-				default: 'snapfu-template-preact',
+				choices: repos.data.filter((repo) => repo.name.startsWith(`snapfu-template-${answers1.framework}`)),
+				default: `snapfu-template-${answers1.framework}`,
 			},
 			{
 				type: 'list',
@@ -109,10 +114,8 @@ export const init = async (options) => {
 				},
 			},
 		];
-
-		const answers = await inquirer.prompt(questions);
-		console.log();
-
+		const answers2 = await inquirer.prompt(questions2);
+		const answers = { ...answers1, ...answers2 };
 		try {
 			await new ConfigApi(answers.secretKey, options.dev).validateSite(answers.siteId);
 		} catch (err) {

--- a/src/init.js
+++ b/src/init.js
@@ -55,11 +55,28 @@ export const init = async (options) => {
 				return org.login;
 			});
 		});
-		let repos = await octokit.rest.repos.listForOrg({
-			org: 'searchspring',
-			type: 'public',
-			per_page: 500,
-		});
+
+		const fetchOrgReposPage = async () => {
+			let page = 0;
+			let per_page = 100;
+			let repos = [];
+			let response;
+			do {
+				page++;
+				response = await octokit.rest.repos.listForOrg({
+					org: 'searchspring',
+					type: 'public',
+					per_page,
+					page,
+				});
+				response.data.map((repo) => {
+					repos.push(repo);
+				});
+			} while (response.data.length == per_page);
+			return repos;
+		};
+
+		let repos = await fetchOrgReposPage();
 
 		let questions = [
 			{
@@ -87,7 +104,7 @@ export const init = async (options) => {
 				type: 'list',
 				name: 'template',
 				message: "Please choose the template you'd like to use:",
-				choices: repos.data.filter((repo) => repo.name.startsWith(`snapfu-template-${answers1.framework}`)),
+				choices: repos.filter((repo) => repo.name.startsWith(`snapfu-template-${answers1.framework}`)),
 				default: `snapfu-template-${answers1.framework}`,
 			},
 			{

--- a/src/recs.js
+++ b/src/recs.js
@@ -47,24 +47,24 @@ export async function initTemplate(options) {
 					return input && input.length > 2;
 				},
 			},
-			{
-				type: 'input',
-				name: 'description',
-				message: 'Please enter a description for the template:',
-			},
-			{
-				type: 'input',
-				name: 'directory',
-				message: 'Please specify the path to initialize the template files (relative to project directory):',
-				validate: (input) => {
-					return input && input.length > 0;
-				},
-				default: framework.template.dir,
-			},
 		]);
 	}
 
 	let answers2 = await inquirer.prompt([
+		{
+			type: 'input',
+			name: 'description',
+			message: 'Please enter a description for the template:',
+		},
+		{
+			type: 'input',
+			name: 'directory',
+			message: 'Please specify the path to initialize the template files (relative to project directory):',
+			validate: (input) => {
+				return input && input.length > 0;
+			},
+			default: framework.template.dir,
+		},
 		{
 			type: 'list',
 			name: 'type',
@@ -290,7 +290,8 @@ export async function getTemplates(dir) {
 			.filter((template) => {
 				if (
 					typeof template.details == 'object' &&
-					template.details.type == TEMPLATE_TYPE_RECS &&
+					template.details.type &&
+					template.details.type.startsWith(TEMPLATE_TYPE_RECS) &&
 					template.details.name &&
 					template.details.label &&
 					template.details.component
@@ -392,6 +393,7 @@ export function buildTemplatePayload(template, vars) {
 				group: template.name,
 				framework: vars.framework || 'unknown',
 				managed: 'true',
+				type: template.type.replace(TEMPLATE_TYPE_RECS, '').replace('/', '') || 'default',
 			},
 			searchspringRecommendProfile: {
 				label: template.label,

--- a/src/recs.js
+++ b/src/recs.js
@@ -36,10 +36,9 @@ export async function initTemplate(options) {
 
 	const framework = frameworks[searchspring.framework];
 	const templateDefaultDir = path.resolve(context.project.path, framework.template.dir);
-	let answers;
-
+	let answers1;
 	if (!nameArg) {
-		answers = await inquirer.prompt([
+		answers1 = await inquirer.prompt([
 			{
 				type: 'input',
 				name: 'name',
@@ -62,17 +61,22 @@ export async function initTemplate(options) {
 				},
 				default: framework.template.dir,
 			},
-			{
-				type: 'list',
-				name: 'type',
-				message: 'Please select the type of recommendations:',
-				choices: Object.keys(framework.template.components),
-				default: 'default',
-			},
 		]);
 	}
 
+	let answers2 = await inquirer.prompt([
+		{
+			type: 'list',
+			name: 'type',
+			message: 'Please select the type of recommendations:',
+			choices: Object.keys(framework.template.components),
+			default: 'default',
+		},
+	]);
+
 	console.log(`Initializing template...`);
+
+	let answers = { ...answers1, ...answers2 };
 
 	const name = nameArg || answers.name;
 	const description = answers && answers.description;


### PR DESCRIPTION
Add an entry to the Recs.json (template descriptor) to identify 'email' type and send this off to smc-config-api when syncing templates 

Add additional recs component template

Create listing (mapping) of recs templates and have inquisitor query what kind of template to initialize when using snapfu recs init (ex: 'default' vs 'email') - similar selection as when initializing a snap project when using snapfu init

Allow new snapfu template for email only projects to be chosen in snapfu init - query the org for templates starting with 'snapfu-template-{{ framework }}' and present options using inquisitor in init.