### PR TITLE
feat: add support for custom patch files

### DIFF
--- a/src/utils/cmp.js
+++ b/src/utils/cmp.js
@@ -4,7 +4,7 @@ export const cmp = (a, b) => {
 
 	// custom patch version if not standard versioning (eg 0.33.0-1)
 	if (pa.length !== 3 || pb.length !== 3) {
-		return 0;
+		return a.localeCompare(b);
 	}
 
 	for (let i = 0; i < 3; i++) {

--- a/src/utils/cmp.js
+++ b/src/utils/cmp.js
@@ -1,6 +1,12 @@
 export const cmp = (a, b) => {
 	const pa = a.split('.');
 	const pb = b.split('.');
+
+	// custom patch version if not standard versioning (eg 0.33.0-1)
+	if (pa.length !== 3 || pb.length !== 3) {
+		return 0;
+	}
+
 	for (let i = 0; i < 3; i++) {
 		const na = Number(pa[i]);
 		const nb = Number(pb[i]);

--- a/src/utils/cmp.test.js
+++ b/src/utils/cmp.test.js
@@ -106,6 +106,53 @@ describe('cmp function', () => {
 		const attemptedSort = shuffledVersions.sort(cmp);
 		expect(attemptedSort).toStrictEqual(sortedVersions);
 	});
+
+	it('can sort versions with letters and custom patches', async () => {
+		const sortedVersions = [
+			'0.0.0',
+			'0.0.1',
+			'0.1.0',
+			'0.2.0',
+			'0.2.0',
+			'0.3.0',
+			'0.3.1',
+			'0.3.1-1',
+			'0.3.1-1',
+			'0.3.2',
+			'0.3.11',
+			'0.3.11-1',
+			'0.3.11-2',
+			'0.3.11-3',
+			'0.3.11-4',
+			'0.3.11-5',
+			'0.3.11-11',
+			'0.3.11-12',
+			'0.3.11-111',
+			'0.3.11-112',
+			'0.3.11-1111',
+			'0.3.11-1112',
+			'0.3.111',
+			'1.0.0',
+			'1.0.0-2',
+			'1.0.0-3',
+			'1.1.0',
+			'1.2.0',
+			'1.2.2',
+			'1.2.22',
+			'1.3.2',
+			'abc123-patch',
+			'custom-patch-1',
+			'custom-patch-2',
+			'custom-patch-3',
+			'xyz123-patch',
+		];
+
+		const shuffledVersions = shuffle(JSON.parse(JSON.stringify(sortedVersions)));
+		expect(shuffledVersions).not.toStrictEqual(sortedVersions);
+
+		const attemptedSort = shuffledVersions.sort(cmp);
+		expect(attemptedSort).toStrictEqual(sortedVersions);
+	});
 });
 
 const shuffle = (array) => {


### PR DESCRIPTION
- Adds support for custom patches to be applied using `snapfu patch apply [name]`
- Should not affect package.json version
- Confirmed that specific patch version or 'latest' still functional and does not include custom patches