### PR TITLE
ci(workflows): adding 'merge' workflow to ensure develop is kept up t…

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,0 +1,29 @@
+name: Merge
+
+on:
+  workflow_run:
+    workflows: ["Publish"]
+    types: [completed]
+
+jobs:
+  Merge:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: "0"
+          ref: "develop"
+
+      - name: Set Github credentials
+        run: |
+          git config user.name searchspring-machine
+          git config user.email machine@searchspring.com
+
+      - name: Merge main into develop branch
+        run: |
+          git merge -X theirs origin/main
+          git push


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate merging the `main` branch into the `develop` branch after a successful completion of the "Publish" workflow.

### New GitHub Actions workflow:

* [`.github/workflows/merge.yml`](diffhunk://#diff-bdb37b2ad65e049a0fc043e88813fdcf7ca0118abc11d99bbda676adfcbbb5a1R1-R29): Added a `Merge` workflow that triggers on the successful completion of the "Publish" workflow. It checks out the repository, sets GitHub credentials, and merges the `main` branch into the `develop` branch using the `-X theirs` strategy to resolve conflicts.